### PR TITLE
Add a 'head' definition to homebrew formula so users can easily compile and install the latest version

### DIFF
--- a/Formula/displayplacer.rb
+++ b/Formula/displayplacer.rb
@@ -2,6 +2,7 @@ class Displayplacer < Formula
   desc "macOS command line utility to configure multi-display resolutions and arrangements. Essentially XRandR for macOS."
   homepage "https://github.com/jakehilborn/displayplacer"
   url "https://github.com/jakehilborn/displayplacer/archive/v1.2.0.tar.gz"
+  head "https://github.com/jakehilborn/displayplacer.git"
   sha256 "95495b09f2b1a4cf63fafd8ea4a3ac916a8b652555966e1e81c1820c540df1f8"
 
   def install


### PR DESCRIPTION
This adds a `head`  definition to the homebrew formula so users can easily compile and install the latest version from github. At the moment if someone installs via homebrew they'll get the old 2019 release. But after this PR they can do `brew install --head displayplacer` to compile and install the latest version.

This somewhat reduces the pressure to update the compiled github release. Instead users can just be directed to install `brew --head displayplacer` when installing to get the latest version.

I tested this on my setup and it worked great.